### PR TITLE
Remove 'app_name' string

### DIFF
--- a/datetimepicker/src/main/res/values/strings.xml
+++ b/datetimepicker/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">DateTimePicker</string>
     <!-- DO NOT TRANSLATE -->
     <string name="time_placeholder">--</string>
 


### PR DESCRIPTION
The library doesn't use the string. And in my app project this is creating a conflict because this library is included before our library module that contains all app strings, including one named `app_name` :disappointed: 